### PR TITLE
Fix some undefined classes in the host script

### DIFF
--- a/host_tools/python/gpu_cc_tool.py
+++ b/host_tools/python/gpu_cc_tool.py
@@ -124,7 +124,7 @@ def find_gpus_sysfs(bdf_pattern=None):
             if cls == "0x068000":
                 # Currently, skip NvSwitch
                 # dev = NvSwitch(dev_path=dev_path)
-				continue
+                continue
             else:
                 dev = Gpu(dev_path=dev_path)
         except UnknownGpuError as err:
@@ -998,7 +998,7 @@ class PciDevice(Device):
                 if pci_dev.vendor == 0x8086:
                     # Currently, fall back to PciBridge code path
                     # return IntelRootPort
-					pass
+                    pass
                 return PciBridge
 
             # Upstream port

--- a/host_tools/python/gpu_cc_tool.py
+++ b/host_tools/python/gpu_cc_tool.py
@@ -122,7 +122,9 @@ def find_gpus_sysfs(bdf_pattern=None):
         cls = cls[0].strip()
         try:
             if cls == "0x068000":
-                dev = NvSwitch(dev_path=dev_path)
+                # Currently, skip NvSwitch
+                # dev = NvSwitch(dev_path=dev_path)
+				continue
             else:
                 dev = Gpu(dev_path=dev_path)
         except UnknownGpuError as err:
@@ -994,7 +996,9 @@ class PciDevice(Device):
             # Root port
             if pci_dev.pciflags["TYPE"] == 0x4:
                 if pci_dev.vendor == 0x8086:
-                    return IntelRootPort
+                    # Currently, fall back to PciBridge code path
+                    # return IntelRootPort
+					pass
                 return PciBridge
 
             # Upstream port


### PR DESCRIPTION
The script `host_tools/python/gpu_cc_tool.py`, which configures the CC mode of the GPU, has some undefined (but used) classes.

Two usages are modified:

* `NvSwitch`. The deployment guide of EA of Nvidia Confidential Computing does not include introduction of `NvSwitch`, so I try skipping its configuration.
* `IntelRootPort`. It might be feasible to treat `IntelRootPort` as `PciBridge`