### PR TITLE
Fix unreferenced variable in local verifier

### DIFF
--- a/guest_tools/gpu_verifiers/local_gpu_verifier/src/verifier/cc_admin.py
+++ b/guest_tools/gpu_verifiers/local_gpu_verifier/src/verifier/cc_admin.py
@@ -419,10 +419,13 @@ def attest(arguments_as_dictionary, nonce, gpu_evidence_list):
                 else:
                     info_log.info("\t\t\tUsing the local driver rim file : " + settings.DRIVER_RIM_PATH)
                     driver_rim = RIM(rim_name='driver', settings=settings, rim_path=settings.DRIVER_RIM_PATH)
-
+                    with open(settings.DRIVER_RIM_PATH, 'rb') as f:
+                        driver_rim_content = f.read()
             else:
                 info_log.info("\t\t\tUsing the local driver rim file : " + settings.DRIVER_RIM_PATH)
                 driver_rim = RIM(rim_name='driver', settings=settings, rim_path=settings.DRIVER_RIM_PATH)
+                with open(settings.DRIVER_RIM_PATH, 'rb') as f:
+                        driver_rim_content = f.read()
             oemid.append(driver_rim.get_manufacturer_id(driver_rim_content))
             driver_rim_verification_status, gpu_driver_attestation_warning = driver_rim.verify(version=driver_version,
                                                                                                settings=settings)


### PR DESCRIPTION
There's a slight error when using the `--test_no_gpu` option and using a local RIM file. When you run the `cc_admin` tool on the `main` branch, you get this error:

```
(prodtest) ➜  local_gpu_verifier git:(main) python3 -m verifier.cc_admin --test_no_gpu --allow_hold_cert
Fetching GPU 0 information from GPU driver.
All GPU Evidences fetched successfully
-----------------------------------
Verifying GPU: GPU-11111111-2222-3333-4444-555555555555
	Driver version fetched : 545.00
	VBIOS version fetched : 96.00.5e.00.01
	Validating GPU certificate chains.
		GPU attestation report certificate chain validation successful.
			The certificate chain revocation status verification successful.
	Authenticating attestation report
		The nonce in the SPDM GET MEASUREMENT request message is matching with the generated nonce.
		Driver version fetched from the attestation report : 545.00
		VBIOS version fetched from the attestation report : 96.00.5e.00.01
		Attestation report signature verification successful.
		Attestation report verification successful.
	Authenticating the RIMs.
		Authenticating Driver RIM
			Using the local driver rim file : /Users/kevinhui/prodtest/lib/python3.10/site-packages/verifier/samples/Driver_RIM_test_no_gpu.swidtag
local variable 'driver_rim_content' referenced before assignment
Traceback (most recent call last):
  File "/Users/kevinhui/homebrew/Cellar/python@3.10/3.10.6_2/Frameworks/Python.framework/Versions/3.10/lib/python3.10/runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/Users/kevinhui/homebrew/Cellar/python@3.10/3.10.6_2/Frameworks/Python.framework/Versions/3.10/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/Users/kevinhui/prodtest/lib/python3.10/site-packages/verifier/cc_admin.py", line 590, in <module>
    main()
  File "/Users/kevinhui/prodtest/lib/python3.10/site-packages/verifier/cc_admin.py", line 147, in main
    result, _ = attest(arguments_as_dictionary, nonce, evidence_list)
  File "/Users/kevinhui/prodtest/lib/python3.10/site-packages/verifier/cc_admin.py", line 551, in attest
    jwt_claims = ClaimsUtils.create_detached_eat_claims(overall_status, gpu_claims_list, nonce, hwmodel, oemid,
  File "/Users/kevinhui/prodtest/lib/python3.10/site-packages/verifier/utils/claims_utils.py", line 128, in create_detached_eat_claims
    gpu_claims["oemid"] = oemid[i]
IndexError: list index out of range
```
The error is here:
```
local variable 'driver_rim_content' referenced before assignment
```

It seems like `driver_rim_content` wasn't assigned in the local branch cases (perhaps that wasn't tested internally?). Anyways, add this fix to reference the local path so that we can get the content read into the program.

It works as intended after this PR:
```
(prodtest) ➜  local_gpu_verifier git:(main) python3 -m verifier.cc_admin --test_no_gpu --allow_hold_cert
Fetching GPU 0 information from GPU driver.
All GPU Evidences fetched successfully
-----------------------------------
Verifying GPU: GPU-11111111-2222-3333-4444-555555555555
	Driver version fetched : 545.00
	VBIOS version fetched : 96.00.5e.00.01
	Validating GPU certificate chains.
		GPU attestation report certificate chain validation successful.
			The certificate chain revocation status verification successful.
	Authenticating attestation report
		The nonce in the SPDM GET MEASUREMENT request message is matching with the generated nonce.
		Driver version fetched from the attestation report : 545.00
		VBIOS version fetched from the attestation report : 96.00.5e.00.01
		Attestation report signature verification successful.
		Attestation report verification successful.
	Authenticating the RIMs.
		Authenticating Driver RIM
			Using the local driver rim file : /Users/kevinhui/prodtest/lib/python3.10/site-packages/verifier/samples/Driver_RIM_test_no_gpu.swidtag
			RIM Schema validation passed.
			driver RIM certificate chain verification successful.
			WARNING: THE CERTIFICATE NVIDIA Reference Value L3 GH100 001 IS REVOKED WITH THE STATUS AS 'CERTIFICATE_HOLD'.
			The certificate chain revocation status verification successful.
			driver RIM signature verification successful.
			Driver RIM verification successful
		Authenticating VBIOS RIM.
			Using the TEST_NO_GPU VBIOS rim file.
			RIM Schema validation passed.
			vbios RIM certificate chain verification successful.
			WARNING: THE CERTIFICATE NVIDIA Reference Value L3 GH100 001 IS REVOKED WITH THE STATUS AS 'CERTIFICATE_HOLD'.
			The certificate chain revocation status verification successful.
			vbios RIM signature verification successful.
			VBIOS RIM verification successful
	Comparing measurements (runtime vs golden)
			The runtime measurements are matching with the golden measurements.
		GPU is in expected state.
	GPU 0 with UUID GPU-11111111-2222-3333-4444-555555555555 verified successfully.
GPU Attestation is Successful.
```