### PR TITLE
Vulnerabilties fixed

### DIFF
--- a/guest_tools/attestation_sdk/README.md
+++ b/guest_tools/attestation_sdk/README.md
@@ -11,7 +11,7 @@ The SDK supports:
 ## Prerequisites
 
 - GPU SKU that supports Confidential Computing
-- Python >= 3.8
+- Python >= 3.9
 
 **For GPU Attestation:**
 - NVIDIA Hopper H100 (or later) GPU that supports CC

--- a/guest_tools/attestation_sdk/pyproject.toml
+++ b/guest_tools/attestation_sdk/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "nv-attestation-sdk"
-version = "2.6.4"
+version = "2.6.5"
 description = "The Attestation SDK provides developers with a easy to use APIs for implementing attestation capabilities into their applications."
 authors = ["Karthik Jayaraman <kjayaraman@nvidia.com>"]
 readme = "README.md"
@@ -12,7 +12,7 @@ keywords = [
 ]
 
 [tool.poetry.dependencies]
-python = ">=3.7"
+python = ">=3.9"
 pyjwt = "~2.7.0"
 requests = "~2.32.3"
 cryptography = "==43.0.1"
@@ -22,13 +22,14 @@ xmlschema = "==2.2.3"
 pyOpenSSL = "==24.2.1"
 PyJWT = "==2.7.0"
 nvidia-ml-py = ">=12.535.77"
-nv-local-gpu-verifier = "2.6.4"
+nv-local-gpu-verifier = "2.6.5"
 build = ">=0.7.0"
 twine = ">=3.7.1"
 pylint = ">=2.9.6"
 pytest = "==8.1.1"
 pytest-cov = ">=5.0.0"
 parameterized = "==0.9.0"
+urllib3 = "2.6.3"
 
 
 [tool.pytest.ini_options]

--- a/guest_tools/gpu_verifiers/local_gpu_verifier/pyproject.toml
+++ b/guest_tools/gpu_verifiers/local_gpu_verifier/pyproject.toml
@@ -1,12 +1,12 @@
 [project]
 name = "nv-local-gpu-verifier"
-version = "2.6.4"
+version = "2.6.5"
 description = "A Python-based tool that validates GPU measurements by comparing GPU runtime measurements with authenticated golden measurements"
 authors = [
     {name = "NVIDIA"}
 ]
 readme = "README.md"
-requires-python = ">=3.7"
+requires-python = ">=3.9"
 license = {text = "BSD-3-Clause"}
 classifiers = [
     "Programming Language :: Python :: 3",
@@ -29,7 +29,8 @@ dependencies = [
     'pyOpenSSL == 24.2.1',
     'PyJWT == 2.7.0',
     'nvidia-ml-py == 12.550.52',
-    'asn1 == 2.7.0'
+    'asn1 == 2.7.0',
+	'urllib3 == 2.6.3'
 ]
 
 [tool.setuptools.package-data]

--- a/guest_tools/ppcie-verifier/pyproject.toml
+++ b/guest_tools/ppcie-verifier/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "nv-ppcie-verifier"
-version = "1.6.5"
+version = "1.6.6"
 description = "Protected PCIE Verifier (1.x version)"
 authors = ["Shwetha Kalyanaraman <skalyanarama@nvidia.com>"]
 license = "OSI Approved :: Apache Software License"
@@ -26,8 +26,9 @@ build = "1.2.1"
 nvidia-ml-py = "^12.550.52"
 prettytable = "^3.10.0"
 pytest-cov = "^5.0.0"
-nv-local-gpu-verifier = "2.6.4"
-nv-attestation-sdk = "2.6.4"
+nv-local-gpu-verifier = "2.6.5"
+nv-attestation-sdk = "2.6.5"
+urllib3 = "2.6.3"
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
- Attestation SDK and Local GPU Verifier now require Python **3.9** or later
- Updated the Attestation SDK C++ submodule to the latest supported version
- Minor Vulnerabilties fixes