### PR TITLE
Add deprecation warnings and bump versions for Python SDK end-of-life

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,9 @@ This repository includes the following attestation tools and utilities:
 
 - **[Local GPU Verifier](guest_tools/gpu_verifiers/local_gpu_verifier/README.md)** - A standalone tool for local GPU attestation verification. *Note: This tool is now integrated into the Attestation SDK. Please use the Attestation SDK for GPU attestation workflows.*
 
-> **Deprecation Notice:** The Python SDK and the Local GPU Verifier is deprecated. Users are encouraged to use the new [C++ SDK](https://docs.nvidia.com/attestation/nv-attestation-sdk-cpp/latest/sdk-c/introduction.html) and the [CLI](https://docs.nvidia.com/attestation/nv-attestation-sdk-cpp/latest/sdk-cli/introduction.html).
+> **Deprecation Notice:** 
+> The Python SDK and the Local GPU Verifier are deprecated. Users are encouraged to use the new [C++ SDK](https://docs.nvidia.com/attestation/nv-attestation-sdk-cpp/latest/sdk-c/introduction.html) and the [CLI](https://docs.nvidia.com/attestation/nv-attestation-sdk-cpp/latest/sdk-cli/introduction.html).
+> For help with migration to the C++ SDK, see the [Migration Guide](https://docs.nvidia.com/attestation/attestation-client-tools-sdk/latest/migration_guide.html).
 
 - **[PPCIE Verifier](guest_tools/ppcie-verifier/README.md)** - Protected PCIe verifier for multi-GPU confidential computing setups where all GPUs are in PPCIE mode, enabling plain-text NVLink traffic while preserving confidential VM security.
 

--- a/guest_tools/attestation_sdk/pyproject.toml
+++ b/guest_tools/attestation_sdk/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "nv-attestation-sdk"
-version = "2.6.5"
+version = "2.7.0"
 description = "The Attestation SDK provides developers with a easy to use APIs for implementing attestation capabilities into their applications."
 authors = ["Karthik Jayaraman <kjayaraman@nvidia.com>"]
 readme = "README.md"
@@ -22,7 +22,7 @@ xmlschema = "==2.2.3"
 pyOpenSSL = "==24.2.1"
 PyJWT = "==2.7.0"
 nvidia-ml-py = ">=12.535.77"
-nv-local-gpu-verifier = "2.6.5"
+nv-local-gpu-verifier = "2.7.0"
 build = ">=0.7.0"
 twine = ">=3.7.1"
 pylint = ">=2.9.6"

--- a/guest_tools/attestation_sdk/src/nv_attestation_sdk/attestation.py
+++ b/guest_tools/attestation_sdk/src/nv_attestation_sdk/attestation.py
@@ -9,6 +9,7 @@ from enum import IntEnum, IntFlag
 import json
 import logging
 import secrets
+import warnings
 import uuid
 
 import jwt
@@ -110,6 +111,17 @@ class Attestation:
             cls._staticNonce = ""
             cls._verifiers = []
             cls._tokens = {}
+            warnings.warn(
+                "nv-attestation-sdk is deprecated and will reach "
+                "end of support on September 15, 2026. "
+                "Please migrate to the C++ SDK: "
+                "https://github.com/NVIDIA/attestation-sdk. "
+                "Migration guide: https://docs.nvidia.com/attestation/"
+                "attestation-client-tools-sdk/latest/"
+                "migration_guide.html",
+                DeprecationWarning,
+                stacklevel=2,
+            )
         return cls._instance
 
     @classmethod

--- a/guest_tools/gpu_verifiers/local_gpu_verifier/pyproject.toml
+++ b/guest_tools/gpu_verifiers/local_gpu_verifier/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nv-local-gpu-verifier"
-version = "2.6.5"
+version = "2.7.0"
 description = "A Python-based tool that validates GPU measurements by comparing GPU runtime measurements with authenticated golden measurements"
 authors = [
     {name = "NVIDIA"}

--- a/guest_tools/gpu_verifiers/local_gpu_verifier/src/verifier/cc_admin.py
+++ b/guest_tools/gpu_verifiers/local_gpu_verifier/src/verifier/cc_admin.py
@@ -33,6 +33,7 @@ import time
 import logging
 import sys
 import base64
+import warnings
 
 from verifier.attestation import AttestationReport
 from verifier.rim import RIM
@@ -80,9 +81,21 @@ gpu_driver_attestation_warning_list = []
 gpu_vbios_attestation_warning_list = []
 
 
+def _print_deprecation_warning():
+    """Print a deprecation warning for nv-local-gpu-verifier."""
+    warnings.warn(
+        "nv-local-gpu-verifier is deprecated and will reach end of support on September 15, 2026. "
+        "Please migrate to the C++ SDK: https://github.com/NVIDIA/attestation-sdk\n"
+        "Migration guide: https://docs.nvidia.com/attestation/attestation-client-tools-sdk/latest/migration_guide.html",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+
+
 def main():
     """ The main function for the CC admin tool.
     """
+    _print_deprecation_warning()
     try:
         global arguments_as_dictionary
         parser = argparse.ArgumentParser()

--- a/guest_tools/ppcie-verifier/ppcie/verifier/verification.py
+++ b/guest_tools/ppcie-verifier/ppcie/verifier/verification.py
@@ -20,6 +20,7 @@ import os
 import secrets
 import sys
 import argparse
+import warnings
 
 from nv_attestation_sdk import attestation
 
@@ -45,6 +46,17 @@ parser = argparse.ArgumentParser()
 logger = setup_logging()
 
 
+def _print_deprecation_warning():
+    """Print a deprecation warning for nv-ppcie-verifier v1.x."""
+    warnings.warn(
+        "nv-ppcie-verifier v1.x is deprecated and will reach end of support on September 15, 2026. "
+        "Please migrate to nv-ppcie-verifier v2.x (ppcie-verifier-sdk-cpp) which uses the C++ SDK.\n"
+        "Migration guide: https://docs.nvidia.com/attestation/attestation-client-tools-sdk/latest/migration_guide.html",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+
+
 def verification():
     """
     This function is the start of PPCIE verification tool.
@@ -53,6 +65,7 @@ def verification():
     present in a correct state.
 
     """
+    _print_deprecation_warning()
     global logger
     status = Status()
     try:

--- a/guest_tools/ppcie-verifier/pyproject.toml
+++ b/guest_tools/ppcie-verifier/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "nv-ppcie-verifier"
-version = "1.6.6"
+version = "1.7.0"
 description = "Protected PCIE Verifier (1.x version)"
 authors = ["Shwetha Kalyanaraman <skalyanarama@nvidia.com>"]
 license = "OSI Approved :: Apache Software License"
@@ -26,8 +26,8 @@ build = "1.2.1"
 nvidia-ml-py = "^12.550.52"
 prettytable = "^3.10.0"
 pytest-cov = "^5.0.0"
-nv-local-gpu-verifier = "2.6.5"
-nv-attestation-sdk = "2.6.5"
+nv-local-gpu-verifier = "2.7.0"
+nv-attestation-sdk = "2.7.0"
 urllib3 = "2.6.3"
 
 [build-system]


### PR DESCRIPTION
- Add runtime DeprecationWarning to nv-attestation-sdk, nv-local-gpu-verifier, and nv-ppcie-verifier v1.x (end of support: September 15, 2026)
- Bump versions: nv-attestation-sdk 2.6.5→2.7.0, nv-local-gpu-verifier 2.6.5→2.7.0, nv-ppcie-verifier 1.6.6→1.7.0
- Update README with migration guide link to C++ SDK
- Update internal cross-dependency pins to match new versions